### PR TITLE
Added BTN_NO_MENU / MDNS_NAME to options

### DIFF
--- a/examples/myoptions.h
+++ b/examples/myoptions.h
@@ -163,6 +163,7 @@ The connection tables are located here https://github.com/e2002/yoradio#connecti
 //#define LIGHT_SENSOR      255               /*  Light sensor  */
 //#define AUTOBACKLIGHT(x)  *function*        /*  Autobacklight function. See options.h for example  */
 //#define DSP_INVERT_TITLE  true              /* Invert title colors for OLED displays ?  */
+//#define MDNS_NAME         yoradio           /* Make the yoradio available at yoradio.local - omitting disables mDNS */
 /******************************************/
 
 /*  IR control  */

--- a/examples/myoptions.h
+++ b/examples/myoptions.h
@@ -105,8 +105,9 @@ The connection tables are located here https://github.com/e2002/yoradio#connecti
 //#define BTN_DOWN              255           /*  Next, Move Down */
 //#define BTN_INTERNALPULLUP    true          /*  Enable the weak pull up resistors */
 //#define BTN_LONGPRESS_LOOP_DELAY    200     /*  Delay between calling DuringLongPress event */
-//#define BTN_CLICK_TICKS    300              /*  Event Timing https://github.com/mathertel/OneButton#event-timing */
-//#define BTN_PRESS_TICKS    500              /*  Event Timing https://github.com/mathertel/OneButton#event-timing */
+//#define BTN_CLICK_TICKS       300           /*  Event Timing https://github.com/mathertel/OneButton#event-timing */
+//#define BTN_PRESS_TICKS       500           /*  Event Timing https://github.com/mathertel/OneButton#event-timing */
+//#define BTN_NO_MENU           true          /* Instead of showing the menu, makes Prev, Next happen immediately */
 
 //#define BTN_MODE              255           /*  MODE switcher  */
 /******************************************/

--- a/yoRadio/src/core/controls.cpp
+++ b/yoRadio/src/core/controls.cpp
@@ -513,7 +513,7 @@ void onBtnClick(int id) {
       }
     case EVT_BTNUP:
     case EVT_BTNDOWN: {
-        if (DSP_MODEL == DSP_DUMMY) {
+        if (DSP_MODEL == DSP_DUMMY || BTN_NO_MENU) {
           if (id == EVT_BTNUP) {
             player.next();
           } else {

--- a/yoRadio/src/core/netserver.cpp
+++ b/yoRadio/src/core/netserver.cpp
@@ -13,6 +13,13 @@
 #ifdef USE_SD
 #include "sdmanager.h"
 #endif
+
+#ifdef MDNS_NAME
+  #include <ESPmDNS.h>  // For multicast DNS
+  #define STRINGIFY(x) #x // trick to convert unquoted macro to a string
+  #define TOSTRING(x) STRINGIFY(x)
+#endif
+
 #ifndef MIN_MALLOC
 #define MIN_MALLOC 24112
 #endif
@@ -97,6 +104,11 @@ bool NetServer::begin(bool quiet) {
   DefaultHeaders::Instance().addHeader(F("Access-Control-Allow-Headers"), F("content-type"));
 #endif
   webserver.begin();
+    #ifdef MDNS_NAME
+      if (!MDNS.begin(TOSTRING(MDNS_NAME))) {
+        Serial.println("Error starting mDNS");
+      }
+    #endif
   websocket.onEvent(onWsEvent);
   webserver.addHandler(&websocket);
 

--- a/yoRadio/src/core/options.h
+++ b/yoRadio/src/core/options.h
@@ -192,6 +192,9 @@ The connection tables are located here https://github.com/e2002/yoradio#connecti
 #ifndef BTN_PRESS_TICKS
   #define BTN_PRESS_TICKS    500
 #endif
+#ifndef BTN_NO_MENU
+  #define BTN_NO_MENU    false
+#endif
 
 /*        TOUCH SCREEN            */
 #define TS_MODEL_UNDEFINED      0


### PR DESCRIPTION
This option will make it possible to allow units with displays to have the same one-click behavior as the units without, skipping the menu for NEXT and PREV.  Minimal update, almost no change to actual code.

I'd also like to add some one-button "favorites" - ie make a button play the first station or make another button play the 10th.  Would you be open to this idea?