### PR TITLE
#bug sntp1 sntp2

### DIFF
--- a/yoRadio/src/core/netserver.cpp
+++ b/yoRadio/src/core/netserver.cpp
@@ -576,7 +576,7 @@ void NetServer::onWsMessage(void *arg, uint8_t *data, size_t len, uint8_t client
         }
         if (tzdone) {
           network.forceTimeSync = true;
-          if (strlen(val) > 0
+          if (strlen(val) > 0)
           config.saveValue(config.store.sntp1, val, 35, true, true);
         }
         return;

--- a/yoRadio/src/core/netserver.cpp
+++ b/yoRadio/src/core/netserver.cpp
@@ -566,7 +566,6 @@ void NetServer::onWsMessage(void *arg, uint8_t *data, size_t len, uint8_t client
         return;
       }
       if (strcmp(cmd, "sntp1") == 0) {
-        strlcpy(config.store.sntp1, val, 35);
         bool tzdone = false;
         if (strlen(config.store.sntp1) > 0 && strlen(config.store.sntp2) > 0) {
           configTime(config.store.tzHour * 3600 + config.store.tzMin * 60, config.getTimezoneOffset(), config.store.sntp1, config.store.sntp2);
@@ -577,7 +576,8 @@ void NetServer::onWsMessage(void *arg, uint8_t *data, size_t len, uint8_t client
         }
         if (tzdone) {
           network.forceTimeSync = true;
-          config.saveValue(config.store.sntp1, val, 35);
+          if (strlen(val) > 0
+          config.saveValue(config.store.sntp1, val, 35, true, true);
         }
         return;
       }


### PR DESCRIPTION
Не происходил EEPROM.commit(), так как аргументы были одинаковы.
При записи пустой строки в sntp1, дальнейшее изменение невозможно.
Включено принудительное сохранение, иначе не происходит запись при изменении только sntp2.