### PR TITLE
Led fix and short messages

### DIFF
--- a/yoRadio/locale/displayL10n_en.h
+++ b/yoRadio/locale/displayL10n_en.h
@@ -69,7 +69,7 @@ const char  const_waitForSD[]    PROGMEM = "INDEX SD";
 
 const char        apNameTxt[]    PROGMEM = "AP NAME";
 const char        apPassTxt[]    PROGMEM = "PASSWORD";
-const char       bootstrFmt[]    PROGMEM = "Trying to %s";
+const char       bootstrFmt[]    PROGMEM = "Wi-fi: %s";
 const char        apSettFmt[]    PROGMEM = "SETTINGS PAGE ON: HTTP://%s/";
 #if EXT_WEATHER
 const char       weatherFmt[]    PROGMEM = "%s, %.1f\011C \007 feels like: %.1f\011C \007 pressure: %d мм \007 humidity: %s%% \007 wind: %.1f m/s [%s]";

--- a/yoRadio/src/displays/conf/displayLCD1602conf.h
+++ b/yoRadio/src/displays/conf/displayLCD1602conf.h
@@ -43,7 +43,7 @@ const ProgressConfig  bootPrgConf  PROGMEM = { 250, 10, 4 };
 /* STRINGS  */
 const char         numtxtFmt[]    PROGMEM = "%d";
 const char        bitrateFmt[]    PROGMEM = "%d";
-//const char        bootstrFmt[]    PROGMEM = "Trying to %s";
+//const char        bootstrFmt[]    PROGMEM = "Wi-fi: %s";
 
 
 /* MOVES  */                             /* { left, top, width } */

--- a/yoRadio/src/main.cpp
+++ b/yoRadio/src/main.cpp
@@ -45,6 +45,9 @@ void setup() {
   #ifdef MQTT_ROOT_TOPIC
     mqttInit();
   #endif
+  #if LED_INVERT
+    if(REAL_LEDBUILTIN!=255) digitalWrite(REAL_LEDBUILTIN, true);Add commentMore actions
+  #endif
   if (config.getMode()==PM_SDCARD) player.initHeaders(config.station.url);
   player.lockOutput=false;
   if (config.store.smartstart == 1) player.sendCommand({PR_PLAY, config.lastStation()});


### PR DESCRIPTION
Two minor fixes:

Wi-fi message shortened for tiny displays

LED_INVERT behavior was not as expected (should light up on boot when music not playing)

