### PR TITLE
Исправление для pluginsManager

### DIFF
--- a/yoRadio/src/pluginsManager/pluginsManager.cpp
+++ b/yoRadio/src/pluginsManager/pluginsManager.cpp
@@ -1,12 +1,17 @@
 #include "pluginsManager.h"
 
-pluginsManager pm;
+pluginsManager& getPluginsManager() {
+  static pluginsManager instance;
+  return instance;
+}
+
+pluginsManager& pm = getPluginsManager();
 
 Plugin::Plugin() {
 }
 
 void Plugin::registerPlugin() {
-  pm.add(this);
+  getPluginsManager().add(this);
 }
 
 void pluginsManager::add(Plugin* plugin) {

--- a/yoRadio/src/pluginsManager/pluginsManager.h
+++ b/yoRadio/src/pluginsManager/pluginsManager.h
@@ -143,7 +143,8 @@ private:
   std::vector<Plugin*> plugins;
 };
 
-extern pluginsManager pm;
+pluginsManager& getPluginsManager();
+extern pluginsManager& pm;
 
 #endif // PLUGINSMANAGER_H
 


### PR DESCRIPTION
Плагины не работали корректно - они регистрировались, но не получали события. 

Заменена глобальная переменная "pluginsManager pm" на синглтон с ленивой инициализацией.

Изменения протестированы, плагины теперь корректно работают и реагируют на события:

<img width="589" height="498" alt="изображение" src="https://github.com/user-attachments/assets/e5b00047-5ec2-4e0e-b59f-09c055598546" />


Просьба добавить исправление в основной код 